### PR TITLE
fix：Fix the issue where the corresponding item is not highlighted after selecting a menu link

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ function createSideBarItems(
       const text = fname.replace(/\.md$/, "");
       const item: DefaultTheme.SidebarItem = {
         text,
-        link: [...reset, `${text}.html`].join("/"),
+        link: '/' + [...reset, `${text}.html`].join("/"),
       };
       result.push(item);
     }


### PR DESCRIPTION
修复菜单链接选中后对应项不高亮（Fix the issue where the corresponding item is not highlighted after selecting a menu link）

修复前（before）：
![image](https://user-images.githubusercontent.com/128951289/236231646-901560fd-32a2-4233-b12b-dd7b3769320d.png)

修复后(after )：
![image](https://user-images.githubusercontent.com/128951289/236231399-2efc2d55-e7f3-4ee5-933e-0b929aa237f6.png)
