### PR TITLE
fix: collapsed don't need a default value

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ function createSideBarItems (
   const {
     ignoreIndexItem,
     deletePrefix,
-    collapsed = false,
+    collapsed,
     sideBarItemsResolved,
     beforeCreateSideBarItems,
     ignoreList = [],


### PR DESCRIPTION
collapsed未传入时有对应的侧边栏场景，无需用false作为默认值
![1717601137391](https://github.com/QC2168/vite-plugin-vitepress-auto-sidebar/assets/57349905/800f9ce2-2177-4076-bdde-cede2af759c2)